### PR TITLE
Fix error displaying project titles without image on mobile phone

### DIFF
--- a/src/components/HorizontalCard.astro
+++ b/src/components/HorizontalCard.astro
@@ -5,7 +5,7 @@ const { title, img, desc, url, badge, tags, target = '_blank' } = Astro.props;
 <div class="rounded-lg bg-base-100 hover:shadow-xl transition ease-in-out hover:scale-[102%]">
   <a href={url} target={target}>
     <div class="hero-content flex-col md:flex-row">
-      <img src={img} alt={title} class="max-w-full md:max-w-[13rem] rounded-lg" />
+      {img && <img src={img} alt={title} class="max-w-full md:max-w-[13rem] rounded-lg" />}
       <div class="grow w-full">
         <h1 class="text-xl font-bold">
           {title}

--- a/src/components/HorizontalShopItem.astro
+++ b/src/components/HorizontalShopItem.astro
@@ -17,7 +17,7 @@ const {
 
 <div class="rounded-lg bg-base-100 hover:shadow-xl transition ease-in-out hover:scale-[102%]">
   <div class="hero-content flex-col md:flex-row">
-    <img src={img} alt={title} class="max-w-full md:max-w-[13rem] rounded-lg" />
+    {img && <img src={img} alt={title} class="max-w-full md:max-w-[13rem] rounded-lg" />}
     <div class="grow w-full p-5 md:p-0">
       <h1 class="text-xl font-bold">
         {title}


### PR DESCRIPTION
When the page is loaded in the browser of a phone, in the projects section the projects that do not have an associated image are displayed as shown in the following image:
<img src="https://user-images.githubusercontent.com/88980449/212599758-b8efb04d-0a84-4196-81a0-730a4bb43318.png"  width="180" height="300">
You can see that a thumbnail of a broken image appears as if the image was not found.
To fix this change the line where the image is loaded in the HorizontalCard component to :

`{img && <img src={img} alt={title} class="max-w-full md:max-w-[13rem] rounded-lg" />}`

The results are shown below:

<img src="https://user-images.githubusercontent.com/88980449/212602147-29c6dc98-fd77-42d2-b432-053486ce608e.png"  width="500" height="200">

<img src="https://user-images.githubusercontent.com/88980449/212602282-ad481a39-d7ca-4ecb-aad6-6c6b1c80a41e.png"  width="180" height="300">

In addition, this would also be the case for the items in the store section. The same change was added in the HorizontalShopItem component. The results are shown below: 

<img src="https://user-images.githubusercontent.com/88980449/212603811-76a2efdf-427b-42f2-af5b-15b9c8384723.png"  width="500" height="200">

<img src="https://user-images.githubusercontent.com/88980449/212603543-825d8aa7-a185-4c17-ae9a-86c6529b873a.png"  width="180" height="300">
