### PR TITLE
feat: custome 404 page and fix sidebar active item style

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ npm run dev
 
 ## Project Strucutre
 
-
-``` php
+```php
 ├── src/
 │   ├── components/
 │   │   ├── cs/
@@ -141,6 +140,7 @@ Include `BaseLayout` in each page you add and `PostLayout` to your post pages.
 You can add a [content collection](https://docs.astro.build/en/guides/content-collections/) in `/content/' folder, you will need add it at config.ts.
 
 #### config.ts
+
 Where you need to define your content collections, we define our content schemas too.
 
 #### Blog
@@ -231,9 +231,9 @@ The configuration for the deployment varies depending on the platform where you 
 
 Suggestions and pull requests are welcomed! Feel free to open a discussion or an issue for a new feature request or bug.
 
-One of the best ways of contribute is to grab a [bug report o feature suggestion](https://github.com/manuelernestog/astro-modern-personal-website/issues) that has been marked `accepted` and dig in.
+One of the best ways of contribute is to grab a [bug report or feature suggestion](https://github.com/manuelernestog/astro-modern-personal-website/issues) that has been marked `accepted` and dig in.
 
-Please be wary of working on issues *not* marked as `accepted`. Just because someone has created an issue doesn't mean we'll accept a pull request for it.
+Please be wary of working on issues _not_ marked as `accepted`. Just because someone has created an issue doesn't mean we'll accept a pull request for it.
 
 ## License
 

--- a/src/components/SideBar.astro
+++ b/src/components/SideBar.astro
@@ -117,10 +117,10 @@
   pages.forEach((elem) => {
     if (url.includes(elem.id)) {
       isHome = false;
-      elem.classList.add("bg-base-300");
+      elem.classList.add("active");
     }
   });
   if (isHome) {
-    homeLink.classList.add("bg-base-300");
+    homeLink.classList.add("active");
   }
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,7 +6,7 @@ import SideBar from "../components/SideBar.astro";
 
 import { SITE_TITLE, SITE_DESCRIPTION } from "../config";
 
-const { image, title = SITE_TITLE, description = SITE_DESCRIPTION } = Astro.props;
+const { image, title = SITE_TITLE, description = SITE_DESCRIPTION, includeSidebar = true } = Astro.props;
 ---
 
 <!DOCTYPE html>
@@ -26,7 +26,7 @@ const { image, title = SITE_TITLE, description = SITE_DESCRIPTION } = Astro.prop
         </div>
         <Footer />
       </div>
-      <SideBar />
+      {includeSidebar && <SideBar />}
     </div>
   </body>
 </html>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,12 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title = "404: Not Found" includeSidebar={false}>
+  <div class="text-center">
+    <h1 class="text-9xl font-bold mb-4">🏝</h1>
+    <h1 class="text-9xl font-bold mb-2">404</h1>
+    <h3 class="text-2xl">The page you're looking for couldn't be found.</h3>
+    <a class="btn btn-accent mt-9" href="/">Home</a>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
This contribution adds:

- A customizable `404: Not Found` page
- Ability to control the existence of the sidebar inside the `BaseLayout` component with props

Fixes:
- The sidebar's active menu item style (based on DaisyUI's official approach)
- Minor typo in the README file